### PR TITLE
cache support for 2.0.0

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,0 +1,8 @@
+gom "github.com/codegangsta/cli"
+gom "github.com/olekukonko/tablewriter"
+gom 'golang.org/x/net/context'
+gom 'golang.org/x/oauth2'
+gom 'golang.org/x/oauth2/google'
+gom 'github.com/google/google-api-go-client/compute/v1'
+gom 'github.com/google/google-api-go-client/cloudresourcemanager/v1beta1'
+gom 'github.com/mitchellh/go-homedir'

--- a/Gomfile.lock
+++ b/Gomfile.lock
@@ -1,0 +1,8 @@
+gom 'github.com/codegangsta/cli', :commit => 'a65b733b303f0055f8d324d805f393cd3e7a7904'
+gom 'github.com/olekukonko/tablewriter', :commit => 'b9346ac189c55dd419f85c7ad2cd56f810bf19d6'
+gom 'golang.org/x/net/context'
+gom 'golang.org/x/oauth2', :commit => 'ad0128250e8fba646a92ca9129716e523d63ef9f'
+gom 'golang.org/x/oauth2/google'
+gom 'github.com/google/google-api-go-client/compute/v1'
+gom 'github.com/google/google-api-go-client/cloudresourcemanager/v1beta1'
+gom 'github.com/mitchellh/go-homedir'

--- a/commands.go
+++ b/commands.go
@@ -156,6 +156,7 @@ func doCache(c *cli.Context) {
 	}
 
 	// gcloud projects list
+	log.Println("loading projects...")
 	service, err := cloudresourcemanager.New(client)
 	if err != nil {
 		panic(err)
@@ -166,9 +167,11 @@ func doCache(c *cli.Context) {
 		panic(err)
 	}
 	cache.Projects = res.Projects
+	log.Printf("loaded projects, %d projects found.\n", len(cache.Projects))
 
 	// gcloud instances list
 	for _, project := range res.Projects {
+		log.Printf("loading instances in %s (%s)...\n", project.Name, project.ProjectId)
 		service, err := compute.New(client)
 		if err != nil {
 			log.Print(err)
@@ -181,12 +184,16 @@ func doCache(c *cli.Context) {
 			continue
 		}
 
+		num_instances := 0
 		for _, instances_scoped_list := range res.Items {
+			num_instances = num_instances + len(instances_scoped_list.Instances)
 			cache.Instances = append(cache.Instances, instances_scoped_list.Instances...)
 		}
+		log.Printf("loaded instances in %s (%s), %d instances found.\n", project.Name, project.ProjectId, num_instances)
 	}
 
 	SaveCache(cache)
+	log.Println("saved cache.")
 }
 
 func doProject(c *cli.Context) {

--- a/commands.go
+++ b/commands.go
@@ -245,11 +245,16 @@ func doSsh(c *cli.Context) {
 		zone = instanceLine[3]
 	}
 
-	sshCom := exec.Command("gcloud", "compute", "--project="+project, "ssh", "--zone="+zone, instance)
+	cmd := []string{"gcloud", "compute", "ssh", instance, "--project=" + project, "--zone=" + zone}
+	log.Println(strings.Join(cmd, " "))
+	sshCom := exec.Command(cmd[0], cmd[1:]...)
 	sshCom.Stdout = os.Stdout
 	sshCom.Stderr = os.Stderr
 	sshCom.Stdin = os.Stdin
-	sshCom.Run()
+	err = sshCom.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func doCurrentProject(c *cli.Context) {

--- a/commands.go
+++ b/commands.go
@@ -256,7 +256,6 @@ func doCurrentProject(c *cli.Context) {
 	config := LoadConfig()
 	project := config.Core.Project
 	fmt.Println("project: " + project)
-	fmt.Printf("%#v", project)
 }
 
 func LoadConfig() configRoot {

--- a/geco.go
+++ b/geco.go
@@ -13,6 +13,7 @@ func main() {
 	app.Usage = ""
 	app.Author = "Shinichirow KAMITO"
 	app.Email = "updoor@gmail.com"
+	app.Authors = []cli.Author{cli.Author{Name: "YAMADA Tsuyoshi", Email: "tyamada@minimum2scp.org"}}
 	app.Commands = Commands
 
 	app.Run(os.Args)


### PR DESCRIPTION
- `geco cache` saves cache into `~/.cache/geco/projects.json`, `~/.cache/geco/instances.json`
- `geco ssh`, `geco project` reads and depends on the cache
- use [google-api-go-client](https://github.com/google/google-api-go-client) instead of `gcloud alpha projects list`, `gcloud compute instances list`
- use [ADC (application default credential)](https://developers.google.com/identity/protocols/application-default-credentials) (`~/.config/gcloud/application_default_credentials.json`) for OAuth2
- add -z (--zsh-widget) option in `geco project`, `geco ssh`
- add Gomfile (use [gom](https://github.com/mattn/gom))
- add @minimum2scp to authors
