### PR TITLE
Clear old cache on `geco cache`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -157,6 +157,8 @@ func doCache(c *cli.Context) {
 	if err != nil {
 		panic(err)
 	}
+	cache.Projects = []*cloudresourcemanager.Project{}
+	cache.Instances = []*compute.Instance{}
 
 	ctx := oauth2.NoContext
 	scopes := []string{compute.ComputeReadonlyScope}


### PR DESCRIPTION
`geco cache` was not cleared old cache, so `geco cache` increases instances.json file...

```
% rm ~/.cache/geco/*.json
% geco cache
(snip)
% ls -lh ~/.cache/geco/*.json
-rw------- 1 yamada yamada 822K  9月 14 15:25 /home/yamada/.cache/geco/instances.json
-rw------- 1 yamada yamada 3.0K  9月 14 15:25 /home/yamada/.cache/geco/projects.json
% geco cache
(snip)
% ls -lh ~/.cache/geco/*.json
-rw------- 1 yamada yamada 1.7M  9月 14 15:26 /home/yamada/.cache/geco/instances.json
-rw------- 1 yamada yamada 3.0K  9月 14 15:26 /home/yamada/.cache/geco/projects.json
% geco cache
(snip)
% ls -lh ~/.cache/geco/*.json
-rw------- 1 yamada yamada 2.5M  9月 14 15:27 /home/yamada/.cache/geco/instances.json
-rw------- 1 yamada yamada 3.0K  9月 14 15:27 /home/yamada/.cache/geco/projects.json
% jq '.[] | select(.name == "xxx-development") | .selfLink' ~/.cache/geco/instances.json
"https://www.googleapis.com/compute/v1/projects/project-id-123/zones/asia-east1-b/instances/xxx-development"
"https://www.googleapis.com/compute/v1/projects/project-id-123/zones/asia-east1-b/instances/xxx-development"
"https://www.googleapis.com/compute/v1/projects/project-id-123/zones/asia-east1-b/instances/xxx-development"
```
