### PR TITLE
Build and release binaries for linux/amd64, darwin/amd64 using Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: go
+sudo: false
+go:
+  - 1.5
+  - tip
+install:
+  - go get github.com/mattn/gom
+  - gom install
+script:
+  - gom build
+  - ./geco
+before_deploy:
+  - go get github.com/mitchellh/gox
+  - gom exec gox -os="linux darwin" -arch="amd64" -output="dist/{{.Dir}}_{{.OS}}_{{.Arch}}/{{.Dir}}"
+  - cd dist && zip geco_linux_amd64.zip  geco_linux_amd64/geco  && cd -
+  - cd dist && zip geco_darwin_amd64.zip geco_darwin_amd64/geco && cd -
+deploy:
+  provider: releases
+  api_key:
+    secure: Ngbq0738SoLtQDxD0Oo8FselloWqlAN3X1vMciPC2/JL3QqcXAkCnMlG/pu7RaQrENILzt5AfeqdP28hng3V4QJ+vu3NAIWjv2cXomo2uYopkz0xdA61vmQIoK15euWaG31XXxIfehoGYZ9bFGfqcsNni6REuBoKCRtoZs9j/gM=
+  file:
+    - dist/geco_linux_amd64.zip
+    - dist/geco_darwin_amd64.zip
+  skip_cleanup: true
+  on:
+    repo: minimum2scp/geco
+    tags: true
+    branch: features/travis-ci
+    condition: "${TRAVIS_GO_VERSION} = 1.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ deploy:
   on:
     repo: minimum2scp/geco
     tags: true
-    branch: features/travis-ci
+    branch: master
     condition: "${TRAVIS_GO_VERSION} = 1.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ install:
 script:
   - gom build
   - ./geco
+matrix:
+  allow_failures:
+    - go: tip
 before_deploy:
   - go get github.com/mitchellh/gox
   - gom exec gox -os="linux darwin" -arch="amd64" -output="dist/{{.Dir}}_{{.OS}}_{{.Arch}}/{{.Dir}}"

--- a/README.md
+++ b/README.md
@@ -8,12 +8,28 @@
  
 geco = gcloud + peco: select GCP resource using peco, and run gcloud
 
+## Dependencies
+
+ * [gcloud (Google Cloud SDK)](https://cloud.google.com/sdk/)
+ * [peco](https://github.com/peco/peco)
+
 ## Installation
 
-To install, use `go get`:
+### Binary install
+
+You can download binary from [Github releases](https://github.com/minimum2scp/geco/releases).
+
+1. Download the zip file and unpack it.
+2. Put binary file into somewhere you want.
+
+### Clone the project (for developers)
 
 ```bash
-$ go get github.com/minimum2scp/geco
+$ go get github.com/mattn/gom
+$ git clone https://github.com/minimum2scp/geco/
+$ cd geco
+$ gom install
+$ gom build
 ```
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE.txt)
 [![Build Status](https://travis-ci.org/minimum2scp/geco.svg)](https://travis-ci.org/minimum2scp/geco)
-[![Gem Version](https://badge.fury.io/rb/geco.svg)](http://badge.fury.io/rb/geco)
 [![Code Climate](https://codeclimate.com/github/minimum2scp/geco/badges/gpa.svg)](https://codeclimate.com/github/minimum2scp/geco)
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Geco
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE.txt)
+[![Build Status](https://travis-ci.org/minimum2scp/geco.svg)](https://travis-ci.org/minimum2scp/geco)
 [![Gem Version](https://badge.fury.io/rb/geco.svg)](http://badge.fury.io/rb/geco)
 [![Code Climate](https://codeclimate.com/github/minimum2scp/geco/badges/gpa.svg)](https://codeclimate.com/github/minimum2scp/geco)
 


### PR DESCRIPTION
After `git tag x.y.z; git push origin x.y.z`, 
[Travis-CI](https://travis-ci.org/minimum2scp/geco) will build binaries for linux/amd64, darwin/amd64,
and creates release, upload binaries (as assets).

![image](https://cloud.githubusercontent.com/assets/162862/10375089/8745657e-6e31-11e5-8340-0bd8e9d1b46b.png)

See also:
- [Building a Go Project](http://docs.travis-ci.com/user/languages/go/)
- [GitHub Releases Uploading](http://docs.travis-ci.com/user/deployment/releases/)
