### PR TITLE
bumped version to 2.0.4, just rebuild with go 1.5.3 for fix potential vulnerability.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.5
+  - 1.5.3
   - tip
 install:
   - go get github.com/mattn/gom
@@ -29,4 +29,4 @@ deploy:
     repo: minimum2scp/geco
     tags: true
     branch: master
-    condition: "${TRAVIS_GO_VERSION} = 1.5"
+    condition: "${TRAVIS_GO_VERSION} = 1.5.3"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version string = "2.0.3"
+const Version string = "2.0.4"


### PR DESCRIPTION
Just rebuild with Go 1.5.3 for fix potential vulnerability.
see https://groups.google.com/forum/#!topic/golang-nuts/MEATuOi_ei4
- [x] @kamito 
