### PR TITLE
golint and refactoring, golang 1.6.2 on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.5.3
+  - 1.6.2
   - tip
 install:
   - go get github.com/golang/lint/golint
@@ -31,4 +31,4 @@ deploy:
     repo: minimum2scp/geco
     tags: true
     branch: master
-    condition: "${TRAVIS_GO_VERSION} = 1.5.3"
+    condition: "${TRAVIS_GO_VERSION} = 1.6.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ go:
   - 1.5.3
   - tip
 install:
+  - go get github.com/golang/lint/golint
   - go get github.com/mattn/gom
   - gom install
 script:
+  - golint .
   - gom build
   - ./geco
 matrix:

--- a/geco.go
+++ b/geco.go
@@ -9,13 +9,13 @@ import (
 func main() {
 	app := cli.NewApp()
 	app.Name = "geco"
-	app.Version = Version
+	app.Version = version
 	app.Usage = ""
 	app.Authors = []cli.Author{
 		cli.Author{Name: "YAMADA Tsuyoshi", Email: "tyamada@minimum2scp.org"},
 		cli.Author{Name: "Shinichirow KAMITO", Email: "updoor@gmail.com"},
 	}
-	app.Commands = Commands
+	app.Commands = commands
 
 	app.Run(os.Args)
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version string = "2.0.4"
+const version string = "2.0.5"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version string = "2.0.4"
+const version string = "2.0.4"


### PR DESCRIPTION
Refactored (variable|fucntion|type) names with `golint`, and use golang 1.6.2 to build binary.

`golint` reported:

```
commands.go:24:5: exported var Commands should have comment or be unexported
commands.go:52:5: var commandSsh should be commandSSH
commands.go:73:5: var maxParallelApiCalls should be maxParallelAPICalls
commands.go:86:6: type projectsById should be projectsByID
commands.go:112:6: don't use underscores in Go names; type t_cache should be tCache
commands.go:118:1: exported function LoadCache should have comment or be unexported
commands.go:118:19: exported func LoadCache returns unexported type *main.t_cache, which can be annoying to use
commands.go:134:4: don't use underscores in Go names; var projects_json should be projectsJSON
commands.go:144:4: don't use underscores in Go names; var instances_json should be instancesJSON
commands.go:158:1: exported function SaveCache should have comment or be unexported
commands.go:159:2: don't use underscores in Go names; var projects_json should be projectsJSON
commands.go:164:2: don't use underscores in Go names; var instances_json should be instancesJSON
commands.go:206:2: don't use underscores in Go names; var projects_list_call should be projectsListCall
commands.go:243:4: don't use underscores in Go names; var aggregated_list_call should be aggregatedListCall
commands.go:255:12: don't use underscores in Go names; range var instances_scoped_list should be instancesScopedList
commands.go:273:9: should omit 2nd value from range; this loop is equivalent to `for _ = range ...`
commands.go:301:2: don't use underscores in Go names; var project_id should be projectID
commands.go:313:6: func doSsh should be doSSH
commands.go:363:1: exported function LoadConfig should have comment or be unexported
commands.go:363:19: exported func LoadConfig returns unexported type main.configRoot, which can be annoying to use
commands.go:385:26: don't use underscores in Go names; func parameter project_id should be projectID
commands.go:398:3: don't use underscores in Go names; var machine_type should be machineType
commands.go:399:3: don't use underscores in Go names; var internal_ip should be internalIP
commands.go:400:3: don't use underscores in Go names; var external_ip should be externalIP
commands.go:417:1: exported function PecoCommand should have comment or be unexported
version.go:3:7: exported const Version should have comment or be unexported
```

(https://travis-ci.org/minimum2scp/geco/jobs/134804558#L173-L199)

All these messages are not shown now.
### reviewers
- [x] @kamito 
