### PR TITLE
Install glide by apt (ppa) in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: go
 sudo: false
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:masterminds/glide'
+    packages:
+      - glide
 go:
   - 1.6.4
   - tip
 install:
   - go get github.com/golang/lint/golint
-  - curl https://glide.sh/get | sh
   - glide install
 script:
   - golint .


### PR DESCRIPTION
Installation of glide (`curl https://glide.sh/get | sh`) is very unstable in Travis CI.

Sometimes it fails,

![image](https://cloud.githubusercontent.com/assets/162862/23049546/258e675c-f500-11e6-8286-65ea82fa98fd.png)

but sometimes it succeeds.

![image](https://cloud.githubusercontent.com/assets/162862/23049599/8ccb4bec-f500-11e6-8a2b-c3398815b799.png)


So I changed to install glide by apt (ppa).

See also:
- https://github.com/Masterminds/glide/issues/639
- https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-on-Container-Based-Infrastructure
